### PR TITLE
Feat/domains list service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xandr-sdk",
-  "version": "1.0.61",
+  "version": "1.0.65",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xandr-sdk",
-      "version": "1.0.61",
+      "version": "1.0.65",
       "license": "UNLICENSED",
       "dependencies": {
         "avsc": "^5.7.7",
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
-        "@types/node": "^17.0.8",
+        "@types/node": "^17.0.45",
         "@types/node-fetch": "^2.6.1",
         "@types/tldjs": "^2.3.1",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
@@ -289,9 +289,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -3714,9 +3714,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
-      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -12,28 +12,30 @@
     "test": "env ENABLE_NOCK=true mocha -r ts-node/register test/**/*.ts",
     "test-no-intercept": "env ENABLE_NOCK=false mocha -r ts-node/register test/**/*.ts"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
-    "@types/node": "^17.0.8",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.1.0",
+    "@types/node": "^17.0.45",
     "@types/node-fetch": "^2.6.1",
     "@types/tldjs": "^2.3.1",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
+    "chai": "^4.3.6",
     "eslint": "^7.32.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.2",
-    "typescript": "^4.4.2",
-    "@types/mocha": "^9.1.0",
-    "@types/chai": "^4.3.0",
     "mocha": "^9.2.2",
-    "chai": "^4.3.6",
+    "nock": "^13.2.4",
     "ts-node": "^10.7.0",
-    "nock": "^13.2.4"
+    "typescript": "^4.4.2"
   },
   "dependencies": {
-    "node-fetch": "^2.6.1",
+    "avsc": "^5.7.7",
     "form-data": "^4.0.0",
-    "tldjs": "^2.3.1",
-    "avsc": "^5.7.7"
+    "node-fetch": "^2.6.1",
+    "tldjs": "^2.3.1"
   }
 }

--- a/src/domain-list/index.ts
+++ b/src/domain-list/index.ts
@@ -5,7 +5,6 @@ import type {
   DomainList,
   DomainListPostParameters,
   DomainListPutParameters,
-  DomainListGetParameters,
   DomainListResponse,
   DomainListsResponse
 } from './types';
@@ -16,6 +15,7 @@ export class XandrDomainListClient {
   private readonly endpoint = 'domain-list';
 
   private readonly defaultHeaders = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     'Content-Type': 'application/json'
   };
 
@@ -23,28 +23,45 @@ export class XandrDomainListClient {
     this.client = client;
   }
 
-  public async get (params: DomainListGetParameters): Promise<DomainList> {
+  public async get (id: number): Promise<DomainList> {
     const response = await this.client.execute<DomainListResponse>({
       method: 'GET',
       endpoint: this.endpoint,
-      query: { ...params }
+      query: { id }
     });
     return response['domain-list'];
   }
 
-  public async getAll (): Promise<DomainList[]> {
-    const DomainLists = [] as DomainList[];
+  public async search (search: string): Promise<DomainList[]> {
+    const domainLists = [] as DomainList[];
     let done = false;
     do {
       const response = await this.client.execute<DomainListsResponse>({
         method: 'GET',
         endpoint: this.endpoint,
-        query: { start_element: DomainLists.length }
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        query: { search, start_element: domainLists.length }
       });
-      DomainLists.push(...response['domain-lists']);
-      done = response.count !== DomainLists.length;
+      domainLists.push(...response['domain-lists']);
+      done = response.count !== domainLists.length;
     } while (!done);
-    return DomainLists;
+    return domainLists;
+  }
+
+  public async getAll (): Promise<DomainList[]> {
+    const domainLists = [] as DomainList[];
+    let done = false;
+    do {
+      const response = await this.client.execute<DomainListsResponse>({
+        method: 'GET',
+        endpoint: this.endpoint,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        query: { start_element: domainLists.length }
+      });
+      domainLists.push(...response['domain-lists']);
+      done = response.count !== domainLists.length;
+    } while (!done);
+    return domainLists;
   }
 
   public async create (props: DomainListPostParameters): Promise<DomainList> {

--- a/src/domain-list/index.ts
+++ b/src/domain-list/index.ts
@@ -1,0 +1,78 @@
+import type { XandrClient } from '..';
+import type { CommonResponse } from '../xandr-types';
+
+import type {
+  DomainList,
+  DomainListPostParameters,
+  DomainListPutParameters,
+  DomainListGetParameters,
+  DomainListResponse,
+  DomainListsResponse
+} from './types';
+
+export class XandrDomainListClient {
+  private readonly client: XandrClient;
+
+  private readonly endpoint = 'domain-list';
+
+  private readonly defaultHeaders = {
+    'Content-Type': 'application/json'
+  };
+
+  public constructor (client: XandrClient) {
+    this.client = client;
+  }
+
+  public async get (params: DomainListGetParameters): Promise<DomainList> {
+    const response = await this.client.execute<DomainListResponse>({
+      method: 'GET',
+      endpoint: this.endpoint,
+      query: { ...params }
+    });
+    return response['domain-list'];
+  }
+
+  public async getAll (): Promise<DomainList[]> {
+    const DomainLists = [] as DomainList[];
+    let done = false;
+    do {
+      const response = await this.client.execute<DomainListsResponse>({
+        method: 'GET',
+        endpoint: this.endpoint,
+        query: { start_element: DomainLists.length }
+      });
+      DomainLists.push(...response['domain-lists']);
+      done = response.count !== DomainLists.length;
+    } while (!done);
+    return DomainLists;
+  }
+
+  public async create (props: DomainListPostParameters): Promise<DomainList> {
+    const response = await this.client.execute<DomainListResponse>({
+      method: 'POST',
+      headers: this.defaultHeaders,
+      endpoint: this.endpoint,
+      body: { 'domain-list': props }
+    });
+    return response['domain-list'];
+  }
+
+  public async modify (id: number, props: DomainListPutParameters): Promise<DomainList> {
+    const response = await this.client.execute<DomainListResponse>({
+      method: 'PUT',
+      headers: this.defaultHeaders,
+      endpoint: this.endpoint,
+      query: { id },
+      body: { 'domain-list': props }
+    });
+    return response['domain-list'];
+  }
+
+  public async delete (id: number): Promise<void> {
+    await this.client.execute<CommonResponse>({
+      method: 'DELETE',
+      endpoint: this.endpoint,
+      query: { id }
+    });
+  }
+}

--- a/src/domain-list/types.ts
+++ b/src/domain-list/types.ts
@@ -10,12 +10,6 @@ export interface DomainList {
   last_modified?: string;
 }
 
-export type DomainListGetParameters = {
-  id: number;
-} | {
-  search: string;
-};
-
 export interface DomainListPostParameters {
   description?: string;
   domains?: string[];

--- a/src/domain-list/types.ts
+++ b/src/domain-list/types.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { CommonResponse } from '../xandr-types';
+
+export interface DomainList {
+  id: number;
+  name: string;
+  description: string;
+  type: string;
+  domains: string[];
+  last_modified?: string;
+}
+
+export type DomainListGetParameters = {
+  id: number;
+} | {
+  search: string;
+};
+
+export interface DomainListPostParameters {
+  description?: string;
+  domains?: string[];
+  name: string;
+  type?: string;
+}
+
+export interface DomainListPutParameters {
+  id: number;
+  description?: string;
+  domains?: string[];
+  name: string;
+  type?: string;
+}
+
+export type DomainListResponse = CommonResponse & {
+  'domain-list': DomainList;
+};
+
+export type DomainListsResponse = CommonResponse & {
+  'domain-lists': DomainList[];
+};


### PR DESCRIPTION
This PR add the Domain List service.
The Domain List service lets you define a list of domains that can be included or excluded from a campaign's targeting profile.
In our case, it will allow us to define and maintain the CDD Gravity and CDD Extended.